### PR TITLE
fix: add postgres volume persistence for locator storage

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       - "5432:5432"
     volumes:
       - ./db/sql/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - healenium_postgres_data:/var/lib/postgresql/data
     environment:
       - POSTGRES_DB=healenium
       - POSTGRES_USER=healenium_user
@@ -128,3 +129,7 @@ services:
 networks:
   healenium:
     name: healenium
+
+    
+volumes:
+  healenium_postgres_data:


### PR DESCRIPTION
Description
Currently, the PostgreSQL database used by Healenium is ephemeral. This means that whenever the Docker containers are stopped, removed, or recreated, all captured locators and healing data are lost.

This PR introduces data persistence by adding a named Docker volume for the Postgres service.

Changes
Added healenium_postgres_data volume mapping to the postgres-db service in docker-compose.yaml.

Defined the healenium_postgres_data volume in the top-level volumes section to ensure it is managed by Docker.

Why this is important
Without this change, users lose their healing history every time they update their environment or restart their machines. Adding this volume ensures that the "self-healing" data actually persists over time.

Testing
[x] Verified that data persists after running docker-compose down followed by docker-compose up.

[x] Confirmed docker-compose config passes with no syntax errors.